### PR TITLE
fix(hf): resolve split-restricted HF dataset hashed configs in offline mode

### DIFF
--- a/src/datamaestro/download/huggingface.py
+++ b/src/datamaestro/download/huggingface.py
@@ -47,6 +47,73 @@ def _base_split(split: str | None) -> str | None:
     return m.group(1) if m else None
 
 
+def _find_cached_hashed_builder(source: str, name: str):
+    """Attempt to find a cached builder matching a hashed config name (e.g. ``quora-ccbd7fec3e15cba7``).
+
+    This happens when ``hf_builder`` restricted ``data_files`` during initial preparation,
+    which caused HF ``datasets`` to save the dataset under a hashed config name.
+    In offline mode, a plain ``load_dataset_builder(source, name)`` fails because the un-hashed
+    config directory does not exist on disk.
+
+    Note on HF ``datasets`` caching quirk:
+    HF ``datasets``' ``cache._find_hash_in_cache`` requires ``dataset_info.json``'s ``config_name``
+    field to match the cache subfolder name (``parts[-3]``). When a hashed builder is prepared,
+    HF ``datasets`` writes the unhashed ``config_name`` into ``dataset_info.json``. To allow
+    HF ``datasets`` cache loader to load the hashed config offline, we ensure ``dataset_info.json``
+    contains the matching hashed config name.
+    """
+    import json
+
+    try:
+        from datasets import load_dataset_builder
+        from datasets.config import HF_DATASETS_CACHE
+    except ModuleNotFoundError:
+        return None
+
+    repo_dir = Path(HF_DATASETS_CACHE) / source.replace("/", "___")
+    if not repo_dir.exists():
+        repo_dir_alt = Path(HF_DATASETS_CACHE) / source.replace("/", "---")
+        if repo_dir_alt.exists():
+            repo_dir = repo_dir_alt
+        else:
+            return None
+
+    matches = sorted(
+        [d for d in repo_dir.iterdir() if d.is_dir() and d.name.startswith(f"{name}-")],
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not matches:
+        return None
+
+    target_dir = matches[0]
+    hashed_name = target_dir.name
+
+    # Check and patch dataset_info.json if HF datasets wrote un-hashed config_name
+    for info_file in target_dir.glob("*/*/dataset_info.json"):
+        try:
+            info = json.loads(info_file.read_text(encoding="utf-8"))
+            if info.get("config_name") != hashed_name:
+                logger.info(
+                    "[hf] Updating %s config_name from '%s' to '%s' for HF datasets cache compatibility",
+                    info_file,
+                    info.get("config_name"),
+                    hashed_name,
+                )
+                info["config_name"] = hashed_name
+                info_file.write_text(json.dumps(info, indent=2), encoding="utf-8")
+        except Exception as exc:
+            logger.warning("[hf] Could not update dataset_info.json at %s: %s", info_file, exc)
+
+    logger.info(
+        "[hf] Offline fallback: using cached split-restricted config '%s' for '%s' (requested config '%s')",
+        hashed_name,
+        source,
+        name,
+    )
+    return load_dataset_builder(source, hashed_name)
+
+
 def hf_builder(
     source: str,
     name: str | None = None,
@@ -74,7 +141,21 @@ def hf_builder(
         logger.error("pip install datasets")
         raise
 
-    builder = load_dataset_builder(source, name, data_files=data_files)
+    try:
+        builder = load_dataset_builder(source, name, data_files=data_files)
+    except Exception as exc:
+        if name is not None and data_files is None:
+            logger.warning(
+                "[hf] load_dataset_builder failed for source='%s', name='%s' (%s). "
+                "Checking for cached split-restricted hashed configs in HF cache...",
+                source,
+                name,
+                exc,
+            )
+            cached_builder = _find_cached_hashed_builder(source, name)
+            if cached_builder is not None:
+                return cached_builder, True
+        raise
 
     base = _base_split(split)
     if base is None:

--- a/src/datamaestro/download/huggingface.py
+++ b/src/datamaestro/download/huggingface.py
@@ -103,7 +103,9 @@ def _find_cached_hashed_builder(source: str, name: str):
                 info["config_name"] = hashed_name
                 info_file.write_text(json.dumps(info, indent=2), encoding="utf-8")
         except Exception as exc:
-            logger.warning("[hf] Could not update dataset_info.json at %s: %s", info_file, exc)
+            logger.warning(
+                "[hf] Could not update dataset_info.json at %s: %s", info_file, exc
+            )
 
     logger.info(
         "[hf] Offline fallback: using cached split-restricted config '%s' for '%s' (requested config '%s')",

--- a/src/datamaestro/test/test_hf.py
+++ b/src/datamaestro/test/test_hf.py
@@ -402,3 +402,35 @@ class TestHFDownloaderCheck:
         r = HFDownloader("hf", repo_id="user/dataset", local_path=missing)
         out = r.check()
         assert out.status.value == "failed"
+
+
+class TestHuggingFaceOfflineHashedFallback:
+    def test_offline_hashed_fallback(self, monkeypatch, tmp_path):
+        from unittest.mock import MagicMock
+        import sys
+        import types
+        from datamaestro.download.huggingface import hf_builder
+
+        cache_dir = tmp_path / "hf_cache"
+        repo_dir = cache_dir / "user___dataset"
+        hashed_dir = repo_dir / "quora-ccbd7fec3e15cba7"
+        hashed_dir.mkdir(parents=True)
+
+        fake = types.ModuleType("datasets")
+        fake.config = types.SimpleNamespace(HF_DATASETS_CACHE=str(cache_dir))
+
+        def mock_load_builder(source, name=None, data_files=None):
+            if name == "quora" and data_files is None:
+                raise ValueError("Couldn't find cache for user/dataset for config 'quora'")
+            builder = MagicMock(name=f"Builder_{name}")
+            builder.config.name = name
+            return builder
+
+        fake.load_dataset_builder = mock_load_builder
+        monkeypatch.setitem(sys.modules, "datasets", fake)
+        monkeypatch.setitem(sys.modules, "datasets.config", fake.config)
+
+        builder, restricted = hf_builder("user/dataset", name="quora", split="train")
+        assert restricted is True
+        assert builder.config.name == "quora-ccbd7fec3e15cba7"
+

--- a/src/datamaestro/test/test_hf.py
+++ b/src/datamaestro/test/test_hf.py
@@ -421,7 +421,9 @@ class TestHuggingFaceOfflineHashedFallback:
 
         def mock_load_builder(source, name=None, data_files=None):
             if name == "quora" and data_files is None:
-                raise ValueError("Couldn't find cache for user/dataset for config 'quora'")
+                raise ValueError(
+                    "Couldn't find cache for user/dataset for config 'quora'"
+                )
             builder = MagicMock(name=f"Builder_{name}")
             builder.config.name = name
             return builder
@@ -433,4 +435,3 @@ class TestHuggingFaceOfflineHashedFallback:
         builder, restricted = hf_builder("user/dataset", name="quora", split="train")
         assert restricted is True
         assert builder.config.name == "quora-ccbd7fec3e15cba7"
-


### PR DESCRIPTION
 ## Description

Fixes an issue where loading split-restricted HuggingFace datasets (e.g. [`quora` with multiple splits](https://huggingface.co/datasets/cross-encoder/ettin-reranker-v1-data/viewer/quora/validation) ) fails in offline mode on compute nodes with  `ValueError: Couldn't find cache for ... for config 'quora'`.
  
## Root Cause & Fix

- When preparing a split-restricted builder, HuggingFace `datasets` saves data under a hashed  
  folder (e.g. `quora-ccbd7fec3e15cba7`), but records `"config_name": "quora"` in `dataset_info.json`.
- In offline mode, `_find_cached_hashed_builder` now locates the hashed cache directory, updates `dataset_info.json`'s `config_name` for HF cache loader compatibility, and loads the  cached builder cleanly.